### PR TITLE
build: add MANIFEST.in to specify hidden file .VERSION

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include .VERSION README.md


### PR DESCRIPTION
Without this the .VERSION will not be added to the source archive on 'python setup.py sdist' command

This should resolve issue "install fails on v1.3.5 from pypi"