### PR TITLE
Lineplotter attr custom resolving issue #46

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The aim of Pypact is to make the FISPACT-II output file easy to parse so that mo
 
 #### <a name="accuracy"></a>Notes on accuracy
 
-Before we get into how to install and use pypact, a small detail regarding accuracy should be noted!
+Before we get into how to install and use pypact, a small detail regarding accuracy should be noted.
 
 It is important to realise that the precision of some values in the FISPACT-II output file can be limited and hence parsing with pypact will give the same precision. It cannot give a more accurate result than the output file.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The aim of Pypact is to make the FISPACT-II output file easy to parse so that mo
 
 #### <a name="accuracy"></a>Notes on accuracy
 
-Before we get into how to install and use pypact, a small detail regarding accuracy should be noted.
+Before we get into how to install and use pypact, a small detail regarding accuracy should be noted!
 
 It is important to realise that the precision of some values in the FISPACT-II output file can be limited and hence parsing with pypact will give the same precision. It cannot give a more accurate result than the output file.
 

--- a/pypact/analysis/plotadapter.py
+++ b/pypact/analysis/plotadapter.py
@@ -51,7 +51,9 @@ class PlotAdapter(object):
         self._figure = self.engine.figure(*args, **kwargs)
         return self._figure
 
-
+    def custom(self, *args, **kwargs):
+        pass
+    
 class LinePlotAdapter(PlotAdapter):
     def lineplot(self, x, y, datalabel="", xlabel="", ylabel="",
                  logx=False, logy=False, overlay=True):
@@ -68,6 +70,9 @@ class LinePlotAdapter(PlotAdapter):
             self.engine.yscale('log')
 
         self.engine.plot(x, y, label=datalabel)
+
+    def custom(self, attr, *args, **kwargs):
+        getattr(self.engine, attr)(*args,**kwargs)
 
 
 class MatrixPlotAdapter(PlotAdapter):


### PR DESCRIPTION
Resolves issue  #46 to allow plotting with plotnuclideheat.py in ppa.TimeZone.BOTH (irradiation and cooling).

Defined attribute custom in both classes PlotAdapter and LinePlotAdapter in plotadapter.py as per comments in issue #46.

In the corresponding plot a vertical line ('axvline') now spawns with legend "cooling" visually separating the irradiation from the cooling interval.