### PR TITLE
Bug metastable plotting

### DIFF
--- a/examples/outputplotting/plotnuclideheat.py
+++ b/examples/outputplotting/plotnuclideheat.py
@@ -3,13 +3,23 @@
 import os
 import pypact as pp
 import pypact.analysis as ppa
+from pypact.library.nuclidelib import get_zai
 
 filename = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                         '..', '..', 'reference', 'test127.out')
 
-tz = ppa.TimeZone.COOL
-properties = ['heat', 'grams', 'ingestion']
-isotopes = [ ppa.NuclideDataEntry(i) for i in ppa.get_all_isotopes() if ppa.find_z(i[0]) <= 10]
+tz = ppa.TimeZone.BOTH
+properties = ['heat', 'grams', 'inhalation']
+
+# plot all isotopes of a specific element regardless of state, here Sc
+#isotopes = [ ppa.NuclideDataEntry(i) for i in ppa.get_all_isotopes() if ppa.find_z(i[0]) == 21]
+
+# plot specific isotope with specific state, here Sc45m
+#isotopes = [ ppa.NuclideDataEntry(i) for i in ppa.get_all_isotopes_states() if get_zai(i[0]+str(i[1])+str(i[2])) == 210451 ]
+
+# plot all isotopes and states of an element, here Sc
+isotopes = [ ppa.NuclideDataEntry(i) for i in ppa.get_all_isotopes_states() if ppa.find_z(i[0]) == 21 ]
+
 
 plt = ppa.LinePlotAdapter()
 

--- a/pypact/analysis/__init__.py
+++ b/pypact/analysis/__init__.py
@@ -11,3 +11,4 @@ from pypact.library.nuclidelib import find_isotopes
 from pypact.library.nuclidelib import find_element
 from pypact.library.nuclidelib import find_z
 from pypact.library.nuclidelib import get_all_isotopes
+from pypact.library.nuclidelib import get_all_isotopes_states

--- a/pypact/analysis/propertyplotter.py
+++ b/pypact/analysis/propertyplotter.py
@@ -7,16 +7,21 @@ class NuclideDataEntry(object):
     def __init__(self, nuclide):
         self.element = nuclide[0]
         self.isotope = nuclide[1]
-
+        try:
+            self.state = nuclide[2]
+        except IndexError:
+            self.state   = ""
+      
         self.reset()
 
     def reset(self):
         self.times = []
         self.values = []
+        
 
     def __str__(self):
-        return str.format("Isotope {0}-{1} values: {2}",
-                          self.element, self.isotope, self.values)
+        return str.format("Isotope {0}-{1}-{2} values: {3}",
+                          self.element, self.isotope, self.state, self.values)
 
 
 def plotproperty(output,
@@ -40,7 +45,7 @@ def plotproperty(output,
             value = getattr(n, property)
             total += value
             for i in isotopes:
-                if n.element == i.element and n.isotope == i.isotope:
+                if n.element == i.element and n.isotope == i.isotope and n.state == i.state:
                     i.times.append(t.irradiation_time + t.cooling_time)
                     i.values.append(value)
 
@@ -60,7 +65,7 @@ def plotproperty(output,
 
         f = plotter.lineplot(x=i.times,
                             y=i.values,
-                            datalabel=str.format('{0}-{1}', i.element, i.isotope),
+                            datalabel=str.format('{0}-{1}{2}', i.element, i.isotope, i.state),
                             xlabel="time [s]",
                             ylabel=yaxislabel,
                             logx=(timeperiod != TimeZone.IRRAD),

--- a/pypact/library/nuclidelib.py
+++ b/pypact/library/nuclidelib.py
@@ -197,3 +197,14 @@ def get_all_isotopes():
                 all_list[count] = (n[ELEMENT_KEY], i)
                 count += 1
     return all_list
+
+def get_all_isotopes_states():
+    all_list_2 = [('', 0,'')] * NUMBER_OF_ISOTOPES * len(STATE_MAPPINGS)
+    count = 0
+    for n in NUCLIDE_DICTIONARY:
+        if ELEMENT_KEY in n and ISOTOPES_KEY in n:
+            for i in n[ISOTOPES_KEY]:
+                for k in STATE_MAPPINGS:
+                    all_list_2[count] = (n[ELEMENT_KEY], i, STATE_MAPPINGS[k])
+                    count += 1
+    return all_list_2


### PR DESCRIPTION
Hi

I tried to fix issue 45: having the possibility to distinguish between isotope states for plotting.

Main changes are to NuclideDataEntry class to have a "state" and nuclidelib.py adding a new function get_all_isotopes_states(). By default get_all_isotopes_states() gives back a list of all isotopes and all states of STATE_MAPPINGS (part of which is "m" for metastable). Don't know if it makes sense to include other STATE_MAPPINGS than "m". Also plotproperty distinguishes the state now.

In plotnuclideheat.py I tried the changes by with different plot examples.

The get_all_isotopes() function also continues working (if there is no interest in the state): added IndexError handling in NuclideDataEntry self.state for this purpose. Not sure if that is good practice. :D

Any feedback would be great!