### PR TITLE
adding density keyword reading from input file

### DIFF
--- a/pypact/input/inputdata.py
+++ b/pypact/input/inputdata.py
@@ -452,3 +452,9 @@ class InputData(JSONSerializable):
                         in_mass_section = False
                 else:
                     raise PypactInvalidOptionException("Invalid element line format in MASS section.")
+
+            elif line.startswith("DENSITY"):
+                parts = line.split()
+                if len(parts) != 2:
+                    raise PypactInvalidOptionException("Invalid DENSITY line format.")
+                self.setDensity(float(parts[1]))

--- a/tests/input/inputfiletest.py
+++ b/tests/input/inputfiletest.py
@@ -28,3 +28,9 @@ class InputFileTest(Tester):
         for i, (element, percentage) in enumerate(expected_elements):
             assert ff._inventorymass.entries[i][0] == element, f"Element {i} should be {element}"
             assert ff._inventorymass.entries[i][1] == percentage, f"Percentage of {element} should be {percentage}"
+
+    def test_reading_in_density(self):
+        ff = pp.InputData()
+        pp.from_file(ff, 'reference/test.i')
+
+        assert ff._density == 19.5


### PR DESCRIPTION
It is really useful to be able to read in the DENSITY along with the MASS keyword added in PR #57 

This small PR adds the ability to read in the DENSITY keyword from an input file.

tagging @jbae11 as I think @jbae11 will also find this useful