### PR TITLE
not adding 0,0 values to irradschedule

### DIFF
--- a/pypact/input/inputdata.py
+++ b/pypact/input/inputdata.py
@@ -489,7 +489,6 @@ class InputData(JSONSerializable):
 
                 # If FLUX is 0.0, we're entering the cooling phase
                 if fluxAmp == 0.0:
-                    self.addIrradiation(0.0, fluxAmp)
                     continue
 
             # Handle TIME entries - can appear after any number of intermediate commands following FLUX

--- a/tests/input/inputfiletest.py
+++ b/tests/input/inputfiletest.py
@@ -42,17 +42,16 @@ class InputFileTest(Tester):
                 [
                     (300.0, 1.1e15),
                     (200.0, 42.0),
-                    (0.0, 0.0),
                 ],
             ),
-            ("reference/test2.i", [(300.0, 1.116e10), (0.0, 0.0)]),
+            ("reference/test2.i", [(300.0, 1.116e10)]),
             (
                 "reference/test3.i",
                 [
                     (300.0, 1.1e14),
                 ],
             ),
-            ("reference/test4.i", [(300.0, 1.116e10), (0.0, 0.0)]),
+            ("reference/test4.i", [(300.0, 1.116e10)]),
             # test case has no ZERO keyword
             (
                 "reference/test5.i",
@@ -60,7 +59,6 @@ class InputFileTest(Tester):
                     (60.0, 1e20),
                     (60.0, 1e20),
                     (60.0, 1e20),
-                    (0, 0),
                     (86400, 0),
                     (86400, 0),
                     (86400, 0),


### PR DESCRIPTION
This PR stops the inputfile reading from adding 0,0 values to the irradschedule

I think this solution makes more sense than adding the values